### PR TITLE
updated version count to use 1.18

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,6 +14,6 @@ license="GPL"
 [[dependencies.horsedebug]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.17,1.18)"
+    versionRange="[1.17,1.19)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
1.18 actually works with the 1.17 forge api, all that needs to change is the version number.